### PR TITLE
Display words with artificial="elliptic" correctly

### DIFF
--- a/src/lib/components/Text/Text.js
+++ b/src/lib/components/Text/Text.js
@@ -9,21 +9,9 @@ import { getColor } from '../Treebank/config';
 
 const formatId = (id) => id.padStart(4, '0');
 
-const formatInsertionId = (insertionId) => {
-  if (/-/.test(insertionId)) {
-    return insertionId.split(/-/)[1];
-  }
-
-  return insertionId;
-};
-
-const wordId = ({ $: { id, insertion_id: insertionId } }) => {
-  if (insertionId) {
-    return formatInsertionId(insertionId);
-  }
-
-  return formatId(id);
-};
+const wordId = ({ $: { id, insertion_id: insertionId } }) => (
+  formatId(insertionId || id)
+);
 
 const compareWords = (wordA, wordB) => {
   const idA = wordId(wordA);
@@ -41,10 +29,22 @@ const compareWords = (wordA, wordB) => {
 };
 
 const wordToSpan = (word, config, active, toggleActive) => {
-  const { $: { id, form, postag } } = word;
+  const {
+    $: {
+      id, form, postag, artificial,
+    },
+  } = word;
   const color = getColor(config, postag);
-  const isActive = active && active.$.id === id;
-  const className = isActive ? [styles.word, styles.active].join(' ') : styles.word;
+  const classes = [styles.word];
+
+  if (active && active.$.id === id) {
+    classes.push(styles.active);
+  }
+
+  if (artificial === 'elliptic') {
+    classes.push(styles.elliptic);
+  }
+
   const onClick = () => {
     toggleActive(word);
   };
@@ -63,7 +63,7 @@ const wordToSpan = (word, config, active, toggleActive) => {
         tabIndex="0"
         onClick={onClick}
         onKeyDown={onKeyDown}
-        className={className}
+        className={classes.join(' ')}
         style={{ color }}
       >
         {form}

--- a/src/lib/components/Text/Text.js
+++ b/src/lib/components/Text/Text.js
@@ -7,8 +7,40 @@ import styles from './Text.module.scss';
 
 import { getColor } from '../Treebank/config';
 
-// eslint-disable-next-line react/prop-types
-const wordToSpan = (config, active, toggleActive, word) => {
+const formatId = (id) => id.padStart(4, '0');
+
+const formatInsertionId = (insertionId) => {
+  if (/-/.test(insertionId)) {
+    return insertionId.split(/-/)[1];
+  }
+
+  return insertionId;
+};
+
+const wordId = ({ $: { id, insertion_id: insertionId } }) => {
+  if (insertionId) {
+    return formatInsertionId(insertionId);
+  }
+
+  return formatId(id);
+};
+
+const compareWords = (wordA, wordB) => {
+  const idA = wordId(wordA);
+  const idB = wordId(wordB);
+
+  if (idA < idB) {
+    return -1;
+  }
+
+  if (idB < idA) {
+    return 1;
+  }
+
+  return 0;
+};
+
+const wordToSpan = (word, config, active, toggleActive) => {
   const { $: { id, form, postag } } = word;
   const color = getColor(config, postag);
   const isActive = active && active.$.id === id;
@@ -43,13 +75,20 @@ const wordToSpan = (config, active, toggleActive, word) => {
 
 const Text = ({
   sentence, active, toggleActive, config,
-}) => (
-  <div className={styles.text}>
-    <p>
-      {sentence.word.map((word) => wordToSpan(config, active, toggleActive, word))}
-    </p>
-  </div>
-);
+}) => {
+  const wordsCopy = [...sentence.word];
+  const spans = wordsCopy
+    .sort(compareWords)
+    .map((word) => wordToSpan(word, config, active, toggleActive));
+
+  return (
+    <div className={styles.text}>
+      <p>
+        {spans}
+      </p>
+    </div>
+  );
+};
 
 Text.propTypes = {
   sentence: sentenceType.isRequired,

--- a/src/lib/components/Text/Text.module.scss
+++ b/src/lib/components/Text/Text.module.scss
@@ -23,3 +23,7 @@
 .active {
   background-color: rgb(246, 217, 24);
 }
+
+.elliptic {
+  font-size: .7rem;
+}

--- a/src/lib/components/Text/Text.test.js
+++ b/src/lib/components/Text/Text.test.js
@@ -31,7 +31,31 @@ it('orders the words of a sentence correctly', () => {
       },
       {
         $: {
-          id: '1', insertion_id: '0001-0004e', form: 'κόσμε', postag: 'n-s---mv-',
+          id: '1', insertion_id: '0004e', form: 'κόσμε', postag: 'n-s---mv-',
+        },
+      },
+    ],
+  };
+
+  const component = (
+    <Text
+      sentence={sentence}
+      active={null}
+      toggleActive={() => {}}
+      config={getConfig('aldt', 'grc')}
+    />
+  );
+  const tree = renderer.create(component).toJSON();
+
+  expect(tree).toMatchSnapshot();
+});
+
+it('styles `artificial="elliptic"` words differently', () => {
+  const sentence = {
+    word: [
+      {
+        $: {
+          id: '1', form: 'Ἡροδότου', postag: 'n-s---mg-', artificial: 'elliptic',
         },
       },
     ],

--- a/src/lib/components/Text/Text.test.js
+++ b/src/lib/components/Text/Text.test.js
@@ -18,3 +18,34 @@ it('renders a sentence', () => {
 
   expect(tree).toMatchSnapshot();
 });
+
+it('orders the words of a sentence correctly', () => {
+  const sentence = {
+    word: [
+      { $: { id: '4', form: 'ὦ', postag: 'e--------' } },
+      { $: { id: '3', form: 'χαῖρε', postag: 'v2spma---' } },
+      {
+        $: {
+          id: '2', insertion_id: '0004f', form: '.', postag: 'u--------',
+        },
+      },
+      {
+        $: {
+          id: '1', insertion_id: '0001-0004e', form: 'κόσμε', postag: 'n-s---mv-',
+        },
+      },
+    ],
+  };
+
+  const component = (
+    <Text
+      sentence={sentence}
+      active={null}
+      toggleActive={() => {}}
+      config={getConfig('aldt', 'grc')}
+    />
+  );
+  const tree = renderer.create(component).toJSON();
+
+  expect(tree).toMatchSnapshot();
+});

--- a/src/lib/components/Text/__snapshots__/Text.test.js.snap
+++ b/src/lib/components/Text/__snapshots__/Text.test.js.snap
@@ -1,5 +1,74 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`orders the words of a sentence correctly 1`] = `
+<div
+  className="text"
+>
+  <p>
+    <span
+      className="word"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+      style={
+        Object {
+          "color": "red",
+        }
+      }
+      tabIndex="0"
+    >
+      χαῖρε
+    </span>
+     
+    <span
+      className="word"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+      style={
+        Object {
+          "color": null,
+        }
+      }
+      tabIndex="0"
+    >
+      ὦ
+    </span>
+     
+    <span
+      className="word"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+      style={
+        Object {
+          "color": "rgb(43, 114, 124)",
+        }
+      }
+      tabIndex="0"
+    >
+      κόσμε
+    </span>
+     
+    <span
+      className="word"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+      style={
+        Object {
+          "color": null,
+        }
+      }
+      tabIndex="0"
+    >
+      .
+    </span>
+     
+  </p>
+</div>
+`;
+
 exports[`renders a sentence 1`] = `
 <div
   className="text"

--- a/src/lib/components/Text/__snapshots__/Text.test.js.snap
+++ b/src/lib/components/Text/__snapshots__/Text.test.js.snap
@@ -92,3 +92,27 @@ exports[`renders a sentence 1`] = `
   </p>
 </div>
 `;
+
+exports[`styles \`artificial="elliptic"\` words differently 1`] = `
+<div
+  className="text"
+>
+  <p>
+    <span
+      className="word elliptic"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+      style={
+        Object {
+          "color": "rgb(43, 114, 124)",
+        }
+      }
+      tabIndex="0"
+    >
+      Ἡροδότου
+    </span>
+     
+  </p>
+</div>
+`;


### PR DESCRIPTION
Fixes https://github.com/perseids-tools/treebank-react/issues/15

There are two parts to this pull request:

1. [2a404fb](https://github.com/perseids-tools/treebank-react/commit/2a404fb0ca65056e959f5c9024a0cd0c5737cf2b) sorts the words in the sentence by the `insertion_id` (if it exists) or `id` (if there is no `insertion_id`).
2. [23d26a9](https://github.com/perseids-tools/treebank-react/commit/23d26a97751f3ca45d807591c90e0ed5fcd80ba2) reduces the font size for words with `artificial="elliptic"`

---

<img width="1106" alt="artificial" src="https://user-images.githubusercontent.com/3039310/99586120-42b66080-29b5-11eb-939a-7191e5385ea0.png">
