### PR TITLE
Style artificial elliptic words in graph

### DIFF
--- a/src/lib/components/Graph/Graph.js
+++ b/src/lib/components/Graph/Graph.js
@@ -10,15 +10,23 @@ import DagreWrapper from './DagreWrapper';
 import { sentenceToGraph } from '../../utils/parsing';
 import { getColor } from '../Treebank/config';
 
-const nodeConfig = (config, active, { id, postag }) => {
+const nodeConfig = (config, active, { id, postag, artificial }) => {
   const color = getColor(config, postag);
   const isActive = active && active.$.id === id;
-  const className = isActive ? [styles.node, styles.active].join(' ') : styles.node;
+  const classes = [styles.node];
+
+  if (isActive) {
+    classes.push(styles.active);
+  }
+
+  if (artificial === 'elliptic') {
+    classes.push(styles.elliptic);
+  }
 
   return {
     labelStyle: `color: ${color}`,
     labelType: 'html',
-    class: className,
+    class: classes.join(' '),
     isActive,
   };
 };

--- a/src/lib/components/Graph/Graph.module.scss
+++ b/src/lib/components/Graph/Graph.module.scss
@@ -58,3 +58,23 @@
     }
   }
 }
+
+.elliptic {
+  :global {
+    .label {
+      div {
+        font-size: 0.7rem;
+
+        // There is an issue when the `font-size` of a `div` within a
+        // `foreignObject` is less than `1rem`. When this happens, Dagre-d3
+        // calculates the correct height for the `div`, but it is not
+        // vertically centered. This results in the bottom of the `div` being
+        // cut off. I'm not sure if this problem is in Dagre-d3 or the way
+        // browsers render SVGs. Whatever the case, setting the `display` to
+        // `table` fixes the issue. Other values for `display` either don't fix
+        // the issue or break the rendering of the graph in other ways.
+        display: table !important;
+      }
+    }
+  }
+}

--- a/src/lib/components/Text/Text.module.scss
+++ b/src/lib/components/Text/Text.module.scss
@@ -25,5 +25,5 @@
 }
 
 .elliptic {
-  font-size: .7rem;
+  font-size: 0.7rem;
 }

--- a/src/lib/utils/parsing.js
+++ b/src/lib/utils/parsing.js
@@ -15,11 +15,11 @@ const sentenceToGraph = (sentence) => {
   sentence.word.forEach((word) => {
     const {
       $: {
-        id, form, head, relation, postag,
+        id, form, head, relation, postag, artificial,
       },
     } = word;
     graph.nodes.push({
-      id, label: form, postag,
+      id, label: form, postag, artificial,
     });
     if (id && head) {
       graph.links.push({ source: head, target: id, label: relation });


### PR DESCRIPTION
Fixes https://github.com/perseids-tools/treebank-react/issues/18

Decrease the font size of `artifical="elliptic"` words to `0.7rem` in the `<Graph>` component. Due to some issues either with Dagre-d3 or with SVG rendering in browsers, the solution is slightly more complicated than setting the `font-size`. See the comment in the `.elliptic` class in `src/lib/components/Graph/Graph.module.scss`.

I tested the solution with Chrome and Firefox on macOS. 

---

<img width="1120" alt="treebank" src="https://user-images.githubusercontent.com/3039310/101652481-49605280-3a0c-11eb-8926-5a62f054ed4b.png">

