### PR TITLE
Refactor Dagre-d3 drawing logic

### DIFF
--- a/src/lib/components/Graph/dagre.js
+++ b/src/lib/components/Graph/dagre.js
@@ -1,5 +1,4 @@
-// TODO - the code in this file along with the logic in parsing.js and Graph.js need to be
-// combined and simplified.
+/* eslint-disable new-cap, func-names, no-underscore-dangle, import/prefer-default-export */
 
 import dagreD3 from 'dagre-d3';
 import * as d3 from 'd3';
@@ -15,183 +14,253 @@ const config = {
   ranksep: 30,
 };
 
-const drawNoChange = (state, nodes, links, prevNodes, prevLinks) => {
-  if (!prevNodes || !prevLinks) {
-    return false;
+// This file provides an interface between React and Dagre-d3. Because React
+// is declarative and Dagre-d3 is imperative, any interface will be a little
+// messy. Hopefully, this file (together with DagreWrapper.js) will be able to
+// contain the mess. The goal is to provide a fully-declarative interface to
+// Dagre-d3.
+//
+// The `drawGraph` function is exported, but the `Dagre` class is where
+// most of the logic lives. The class is instantiated with the nodes, links,
+// previous nodes, previous links, a callback that should be called when a node
+// is clicked, and some d3 elements.
+//
+// The `draw` function works like a state machine and executes all the logic
+// necessary for determining whether the graph should be redrawn and how to draw
+// it. For example, if several nodes have been added, the entire graph is
+// redrawn. But if the only change is the active node, the graph is not redrawn.
+// Instead, the CSS classes of the active node and previously active node are
+// changed.
+//
+// See the comments in the `draw` function for more information.
+class Dagre {
+  constructor(selectedSvg, selectedG, nodes, links, onClick, prevNodes, prevLinks) {
+    this.selectedSvg = selectedSvg;
+    this.selectedG = selectedG;
+    this.nodes = nodes;
+    this.links = links;
+    this.onClick = onClick;
+    this.prevNodes = prevNodes;
+    this.prevLinks = prevLinks;
+
+    this.state = 'initial';
+
+    // Instance variables that can be set or unset as part of a state transition
+    this.active = null;
+    this.previousActive = null;
+
+    this.draw = this.draw.bind(this);
+    this.checkGraphSize = this.checkGraphSize.bind(this);
+    this.redraw = this.redraw.bind(this);
+    this.checkLinks = this.checkLinks.bind(this);
+    this.checkNodes = this.checkNodes.bind(this);
+    this.drawActive = this.drawActive.bind(this);
   }
 
-  if (nodes.length !== prevNodes.length) {
-    return false;
-  }
-
-  if (links.length !== prevLinks.length) {
-    return false;
-  }
-
-  let ii;
-
-  for (ii = 0; ii < links.length; ii += 1) {
-    const link = links[ii];
-    const prevLink = prevLinks[ii];
-
-    if (link.head !== prevLink.head
-      || link.target !== prevLink.target
-      || link.label !== prevLink.label) {
-      return false;
-    }
-  }
-  // eslint-disable-next-line no-param-reassign
-  state.linksIdentical = true;
-
-  for (ii = 0; ii < nodes.length; ii += 1) {
-    const node = nodes[ii];
-    const prevNode = prevNodes[ii];
-
-    if (node.id !== prevNode.id
-      || node.label !== prevNode.label
-      || node.postag !== prevNode.postag
-      || node.config.isActive !== prevNode.config.isActive) {
-      return false;
-    }
-  }
-
-  return true;
-};
-
-const drawChangeActive = (state, selectedG, nodes, prevNodes, onClick) => {
-  if (!state.linksIdentical) {
-    return false;
-  }
-
-  if (!prevNodes) {
-    return false;
-  }
-
-  if (nodes.length !== prevNodes.length) {
-    return false;
-  }
-
-  let ii; let active; let
-    prevActive;
-
-  for (ii = 0; ii < nodes.length; ii += 1) {
-    const node = nodes[ii];
-    const prevNode = prevNodes[ii];
-
-    if (node.id !== prevNode.id
-      || node.label !== prevNode.label
-      || node.postag !== prevNode.postag) {
-      return false;
+  draw() {
+    if (this.state === 'complete') {
+      return;
     }
 
-    if (prevNode.config.isActive) {
-      prevActive = prevNode;
-    }
+    const transitions = {
+      // Checks for changes in the number of nodes and links
+      // -> sameSize : if the number of nodes and number of  links haven't changed
+      // -> redraw   : if there are changes or if there is no previous graph
+      initial: this.checkGraphSize,
 
-    if (node.config.isActive) {
-      active = node;
-    }
+      // Checks for any changes between `links` and `prevLinks`
+      // -> linksIdentical : if there are no changes
+      // -> redraw         : if there are changes
+      sameSize: this.checkLinks,
+
+      // Checks for any changes between `nodes` and `prevNodes`
+      // Also checks whether the active node has changed
+      // (Sets `this.active` and `this.previousActive`)
+      // -> complete      : if there are no changes
+      // -> activeChanged : if the only change is the active node
+      // -> redraw        : if there are any other changes
+      linksIdentical: this.checkNodes,
+
+      // Adds the `active` class to the active node in the graph
+      // Removes the `active` class from the previously active node
+      // Makes no other change to the graph
+      // -> complete
+      activeChanged: this.drawActive,
+
+      // Draws the graph
+      // If the graph has already been drawn, this function redraws it
+      // -> complete
+      redraw: this.redraw,
+    };
+
+    transitions[this.state]();
+
+    this.draw();
   }
 
-  // eslint-disable-next-line func-names
-  selectedG.selectAll('g.node').each(function () {
-    // eslint-disable-next-line no-underscore-dangle
-    if (active && this.__data__ === active.id) {
-      this.classList.add(styles.active);
-      d3.select(this).on('mousedown', ({ target }) => {
-        // eslint-disable-next-line no-underscore-dangle
-        onClick(target.__data__);
-      });
+  checkGraphSize() {
+    if (!this.prevNodes || !this.prevLinks
+      || this.nodes.length !== this.prevNodes.length
+      || this.links.length !== this.prevLinks.length) {
+      this.state = 'redraw';
+
+      return;
     }
 
-    // eslint-disable-next-line no-underscore-dangle
-    if (prevActive && this.__data__ === prevActive.id) {
-      this.classList.remove(styles.active);
-      d3.select(this).on('mousedown', ({ target }) => {
-        // eslint-disable-next-line no-underscore-dangle
-        onClick(target.__data__);
-      });
-    }
-  });
-
-  return true;
-};
-
-const setInitialPosition = (selectedSvg, zoom) => {
-  const node = selectedSvg.node();
-  const bounds = node.getBBox();
-  const width = node.clientWidth;
-
-  if (bounds.width > width - (treeMargin * 2)) {
-    const offset = d3.zoomIdentity.translate(treeMargin, treeMargin);
-    const scale = (width - treeMargin * 2) / bounds.width;
-
-    selectedSvg.call(zoom.transform, offset.scale(scale));
-  } else {
-    const offset = d3.zoomIdentity.translate((width - bounds.width) / 2, treeMargin);
-
-    selectedSvg.call(zoom.transform, offset);
+    this.state = 'sameSize';
   }
-};
 
-const drawInitial = (state, selectedSvg, selectedG, nodes, links, onClick) => {
-  const graph = new dagreD3.graphlib.Graph().setGraph(config);
+  checkLinks() {
+    let ii;
 
-  nodes.forEach(({
-    id, label, config: { labelType, labelStyle, class: className },
-  }) => {
-    graph.setNode(id, {
-      label,
-      labelType,
-      labelStyle,
-      class: className,
-      paddingLeft: 2,
-      paddingRight: 2,
-      paddingTop: 2,
-      paddingBottom: 2,
+    for (ii = 0; ii < this.links.length; ii += 1) {
+      const link = this.links[ii];
+      const prevLink = this.prevLinks[ii];
+
+      if (link.head !== prevLink.head
+        || link.source !== prevLink.source
+        || link.target !== prevLink.target
+        || link.label !== prevLink.label) {
+        this.state = 'redraw';
+
+        return;
+      }
+    }
+
+    this.state = 'linksIdentical';
+  }
+
+  checkNodes() {
+    let ii;
+
+    for (ii = 0; ii < this.nodes.length; ii += 1) {
+      const node = this.nodes[ii];
+      const prevNode = this.prevNodes[ii];
+
+      if (node.id !== prevNode.id
+        || node.label !== prevNode.label
+        || node.postag !== prevNode.postag) {
+        this.state = 'redraw';
+
+        return;
+      }
+
+      if (prevNode.config.isActive) {
+        this.previousActive = prevNode;
+      }
+
+      if (node.config.isActive) {
+        this.active = node;
+      }
+    }
+
+    if ((this.active && !this.previousActive)
+      || (!this.active && this.previousActive)
+      || (this.active && this.previousActive && this.active.id !== this.previousActive.id)) {
+      this.state = 'activeChanged';
+
+      return;
+    }
+
+    this.state = 'complete';
+  }
+
+  drawActive() {
+    const { active } = this;
+    const { previousActive } = this;
+    const { onClick } = this;
+
+    this.selectedG.selectAll('g.node').each(function () {
+      if (active && this.__data__ === active.id) {
+        this.classList.add(styles.active);
+
+        // For some reason, the listener has to be re-added to manipulated nodes
+        d3.select(this).on('mousedown', ({ target }) => {
+          onClick(target.__data__);
+        });
+      }
+
+      if (previousActive && this.__data__ === previousActive.id) {
+        this.classList.remove(styles.active);
+        d3.select(this).on('mousedown', ({ target }) => {
+          onClick(target.__data__);
+        });
+      }
     });
-  });
 
-  links.forEach(({
-    source, target, label, config: { arrowheadStyle },
-  }) => {
-    graph.setEdge(source, target, { label, arrowheadStyle, curve: d3.curveBasis });
-  });
+    this.state = 'complete';
+  }
 
-  // eslint-disable-next-line new-cap
-  const renderer = new dagreD3.render();
-  const zoom = d3.zoom().on('zoom', (event) => {
-    selectedG.attr('transform', event.transform);
-  }).scaleExtent([0.3, 2.5]);
+  redraw() {
+    const graph = new dagreD3.graphlib.Graph().setGraph(config);
 
-  selectedSvg.call(zoom);
+    this.nodes.forEach(({
+      id, label, config: { labelType, labelStyle, class: className },
+    }) => {
+      graph.setNode(id, {
+        label,
+        labelType,
+        labelStyle,
+        class: className,
+        paddingLeft: 2,
+        paddingRight: 2,
+        paddingTop: 2,
+        paddingBottom: 2,
+      });
+    });
 
-  selectedG.attr('transform', d3.zoomIdentity);
+    this.links.forEach(({
+      source, target, label, config: { arrowheadStyle },
+    }) => {
+      graph.setEdge(source, target, { label, arrowheadStyle, curve: d3.curveBasis });
+    });
 
-  renderer(selectedG, graph);
+    const renderer = new dagreD3.render();
+    const zoom = d3.zoom().on('zoom', (event) => {
+      this.selectedG.attr('transform', event.transform);
+    }).scaleExtent([0.3, 2.5]);
 
-  setInitialPosition(selectedSvg, zoom);
+    this.selectedSvg.call(zoom);
 
-  selectedSvg.selectAll('g.node').on('mousedown', ({ target }) => {
-    // eslint-disable-next-line no-underscore-dangle
-    onClick(target.__data__);
-  });
+    this.selectedG.attr('transform', d3.zoomIdentity);
 
-  return true;
-};
+    renderer(this.selectedG, graph);
+
+    this.setInitialPosition(zoom);
+
+    this.selectedSvg.selectAll('g.node').on('mousedown', ({ target }) => {
+      this.onClick(target.__data__);
+    });
+
+    this.state = 'complete';
+  }
+
+  setInitialPosition(zoom) {
+    const node = this.selectedSvg.node();
+    const bounds = node.getBBox();
+    const width = node.clientWidth;
+
+    if (bounds.width > width - (treeMargin * 2)) {
+      const offset = d3.zoomIdentity.translate(treeMargin, treeMargin);
+      const scale = (width - treeMargin * 2) / bounds.width;
+
+      this.selectedSvg.call(zoom.transform, offset.scale(scale));
+    } else {
+      const offset = d3.zoomIdentity.translate((width - bounds.width) / 2, treeMargin);
+
+      this.selectedSvg.call(zoom.transform, offset);
+    }
+  }
+}
 
 const drawGraph = (svg, g, nodes, links, onClick, prevNodes, prevLinks) => {
   const selectedSvg = d3.select(svg.current);
   const selectedG = d3.select(g.current);
-  const state = {};
+  const graph = new Dagre(selectedSvg, selectedG, nodes, links, onClick, prevNodes, prevLinks);
 
-  // eslint-disable-next-line no-unused-expressions
-  drawNoChange(state, nodes, links, prevNodes, prevLinks)
-  || drawChangeActive(state, selectedG, nodes, prevNodes, onClick)
-  || drawInitial(state, selectedSvg, selectedG, nodes, links, onClick);
+  graph.draw();
 };
 
 export {
-  // eslint-disable-next-line import/prefer-default-export
   drawGraph,
 };


### PR DESCRIPTION
Partially addresses https://github.com/perseids-tools/treebank-react/issues/12

Refactor the logic used by the `drawGraph` function in `dagre.js` to be (hopefully) easier to understand and more flexible. Also add comments explaining how the functionality works.

This PR looks like a bigger change than it actually is. Most of the diffs are either white space or a change from `variable` to `this.variable`. The logic of each function has mostly remained the same.