### PR TITLE
Allow more external control

### DIFF
--- a/src/lib/components/Graph/Graph.js
+++ b/src/lib/components/Graph/Graph.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { func, instanceOf } from 'prop-types';
 
 import { sentenceType, wordType } from '../../types';
@@ -14,10 +14,6 @@ const Graph = ({
   sentence, active, toggleActive, config,
 }) => {
   const { nodes, links } = sentenceToGraph(sentence, active, config, styles);
-
-  useEffect(() => {
-    toggleActive(null);
-  }, [sentence]);
 
   return (
     <DagreWrapper

--- a/src/lib/components/Graph/Graph.js
+++ b/src/lib/components/Graph/Graph.js
@@ -10,10 +10,6 @@ import DagreWrapper from './DagreWrapper';
 import { sentenceToGraph } from '../../utils/parsing';
 import { Configuration } from '../../utils/config';
 
-const findWord = (wordId, sentence) => (
-  sentence.word.find(({ $: { id } }) => id === wordId)
-);
-
 const Graph = ({
   sentence, active, toggleActive, config,
 }) => {
@@ -27,7 +23,7 @@ const Graph = ({
     <DagreWrapper
       nodes={nodes}
       links={links}
-      onClick={(id) => toggleActive(findWord(id, sentence))}
+      onClick={toggleActive}
     />
   );
 };

--- a/src/lib/components/Text/Text.js
+++ b/src/lib/components/Text/Text.js
@@ -46,7 +46,7 @@ const wordToSpan = (word, config, active, toggleActive) => {
   }
 
   const onClick = () => {
-    toggleActive(word);
+    toggleActive(id);
   };
   const onKeyDown = (event) => {
     const { key } = event;

--- a/src/lib/components/Treebank/Sentence/Sentence.js
+++ b/src/lib/components/Treebank/Sentence/Sentence.js
@@ -16,9 +16,18 @@ const findWord = (wordId, sentence) => (
 
 const WrappedSentence = ({
   // eslint-disable-next-line react/prop-types
-  id, callback, json, config, children,
+  id, callback, active: externalActiveId, setActive: externalSetActiveId, json, config, children,
 }) => {
-  const [activeId, setActiveId] = useState(null);
+  let activeId;
+  let setActiveId;
+
+  if (externalActiveId !== null || externalSetActiveId !== null) {
+    activeId = externalActiveId;
+    setActiveId = externalSetActiveId || (() => {});
+  } else {
+    [activeId, setActiveId] = useState(null);
+  }
+
   const sentence = sentenceFromJson(json, id);
 
   const active = findWord(activeId, sentence);
@@ -39,6 +48,10 @@ const WrappedSentence = ({
     }
   }, [id, json]);
 
+  useEffect(() => {
+    setActiveId(externalActiveId);
+  }, [id, json]);
+
   return (
     <SentenceContext.Provider value={{
       sentence,
@@ -54,12 +67,16 @@ const WrappedSentence = ({
   );
 };
 
-const Sentence = ({ id, callback, children }) => (
+const Sentence = ({
+  id, callback, active, setActive, children,
+}) => (
   <TreebankContext.Consumer>
     {({ json, config }) => (
       <WrappedSentence
         id={id}
         callback={callback}
+        active={active}
+        setActive={setActive}
         json={json}
         config={config}
       >
@@ -72,11 +89,15 @@ const Sentence = ({ id, callback, children }) => (
 Sentence.propTypes = {
   id: string.isRequired,
   callback: func,
+  active: string,
+  setActive: func,
   children: node,
 };
 
 Sentence.defaultProps = {
   callback: null,
+  active: null,
+  setActive: null,
   children: null,
 };
 

--- a/src/lib/components/Treebank/Sentence/Sentence.js
+++ b/src/lib/components/Treebank/Sentence/Sentence.js
@@ -10,18 +10,26 @@ const sentenceFromJson = (json, id) => (
   json.treebank.sentence.find(({ $ }) => $.id && $.id === id)
 );
 
+const findWord = (wordId, sentence) => (
+  sentence.word.find(({ $: { id } }) => id === wordId)
+);
+
 const WrappedSentence = ({
   // eslint-disable-next-line react/prop-types
   id, callback, json, config, children,
 }) => {
-  const [active, setActive] = useState(null);
+  const [activeId, setActiveId] = useState(null);
   const sentence = sentenceFromJson(json, id);
 
-  const toggleActive = (word) => {
-    if (word && active && word.$.id === active.$.id) {
-      setActive(null);
+  const active = findWord(activeId, sentence);
+
+  const toggleActive = (wordId) => {
+    const newActive = findWord(wordId, sentence);
+
+    if (newActive && active && activeId === wordId) {
+      setActiveId(null);
     } else {
-      setActive(word);
+      setActiveId(wordId);
     }
   };
 

--- a/src/lib/components/Treebank/Treebank.js
+++ b/src/lib/components/Treebank/Treebank.js
@@ -1,5 +1,5 @@
-import React, { useMemo, useState } from 'react';
-import { node, string } from 'prop-types';
+import React, { useMemo, useState, useEffect } from 'react';
+import { node, string, func } from 'prop-types';
 
 import { xmlToJson } from '../../utils/parsing';
 import { getConfig } from '../../utils/config';
@@ -15,11 +15,19 @@ const configFromJson = (json, configUrl, callback) => (
   )
 );
 
-const Treebank = ({ treebank, configUrl, children }) => {
+const Treebank = ({
+  treebank, configUrl, callback, children,
+}) => {
   const [config, setConfig] = useState(null);
   const json = useMemo(() => xmlToJson(treebank), [treebank]);
 
   useMemo(() => configFromJson(json, configUrl, setConfig), [treebank]);
+
+  useEffect(() => {
+    if (callback) {
+      callback(json);
+    }
+  }, [treebank]);
 
   if (config) {
     return (
@@ -37,11 +45,13 @@ const Treebank = ({ treebank, configUrl, children }) => {
 Treebank.propTypes = {
   treebank: string.isRequired,
   configUrl: string,
+  callback: func,
   children: node,
 };
 
 Treebank.defaultProps = {
   configUrl: 'https://arethusa-configs.perseids.org/',
+  callback: null,
   children: null,
 };
 

--- a/src/lib/components/Xml/Xml.js
+++ b/src/lib/components/Xml/Xml.js
@@ -52,7 +52,7 @@ const renderWord = (word, active, toggleActive) => {
   const isActive = active && active.$.id === id;
   const className = isActive ? [styles.word, styles.active].join(' ') : styles.word;
   const onClick = () => {
-    toggleActive(word);
+    toggleActive(id);
   };
   const onKeyDown = (event) => {
     const { key } = event;


### PR DESCRIPTION
Fixes https://github.com/perseids-tools/treebank-react/issues/8

This PR adds the necessary functionality in order for the Treebank Template to be able to implement everything listed [here](https://github.com/perseids-tools/treebank-react/issues/8#issuecomment-745460127). There are two pieces involved:

1. Optional `active` and `setActive` props in the `<Sentence>` component. If one of these is passed in, it will be used instead of the internal `<Sentence>` state. This allows a user to render a sentence with a particular word selected: `<Sentence id="1" active="3">...</Sentence>` or use external state: `<Sentence id="1" setActive={mySetActive} active={myActive}>...</Sentence>`.
2. A `callback` prop to the `<Treebank>` component. This is a function that is called after the treebank is parsed and it is given the treebank JSON as its argument.