### PR TITLE
Highlight particular words in a sentence

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ The other components should be children (or grandchildren, etc.) of the `<Treeba
 The `<Sentence>` component accepts a string `id` which represents the `id` of the
 sentence to display.
 
+It also accepts an optional `highlight` prop. This is an array of `id` strings to be
+emphasized by the child components.
+
 #### Graph
 
 The `<Graph>` component must be within a `<Sentence>` component.

--- a/src/lib/components/Graph/Graph.js
+++ b/src/lib/components/Graph/Graph.js
@@ -11,9 +11,9 @@ import { sentenceToGraph } from '../../utils/parsing';
 import { Configuration } from '../../utils/config';
 
 const Graph = ({
-  sentence, active, toggleActive, config,
+  sentence, active, toggleActive, highlight, config,
 }) => {
-  const { nodes, links } = sentenceToGraph(sentence, active, config, styles);
+  const { nodes, links } = sentenceToGraph(sentence, active, highlight, config, styles);
 
   return (
     <DagreWrapper
@@ -28,11 +28,13 @@ Graph.propTypes = {
   sentence: sentenceType.isRequired,
   active: wordType,
   toggleActive: func.isRequired,
+  highlight: instanceOf(Set),
   config: instanceOf(Configuration).isRequired,
 };
 
 Graph.defaultProps = {
   active: null,
+  highlight: new Set(),
 };
 
 export default Graph;

--- a/src/lib/components/Graph/Graph.module.scss
+++ b/src/lib/components/Graph/Graph.module.scss
@@ -1,5 +1,5 @@
 .graph {
-  background-color: rgb(242, 242, 242);
+  background-color: #f2f2f2;
   cursor: grab;
   width: 100%;
 
@@ -42,7 +42,7 @@
         cursor: pointer;
 
         &:hover {
-          background-color: #5BC8DC;
+          background-color: #5bc8dc;
         }
       }
     }
@@ -53,7 +53,17 @@
   :global {
     .label {
       div {
-        background-color: rgb(246, 217, 24);
+        background-color: #f6d918;
+      }
+    }
+  }
+}
+
+.highlight {
+  :global {
+    .label {
+      div {
+        background-color: #98eb09;
       }
     }
   }

--- a/src/lib/components/Graph/Graph.test.js
+++ b/src/lib/components/Graph/Graph.test.js
@@ -25,7 +25,6 @@ it('renders a sentence', () => {
   const component = (
     <Graph
       sentence={sentence}
-      active={null}
       toggleActive={() => {}}
       config={global.defaultConfig}
     />

--- a/src/lib/components/Text/Text.js
+++ b/src/lib/components/Text/Text.js
@@ -28,7 +28,7 @@ const compareWords = (wordA, wordB) => {
   return 0;
 };
 
-const wordToSpan = (word, config, active, toggleActive) => {
+const wordToSpan = (word, config, active, highlight, toggleActive) => {
   const {
     $: {
       id, form, postag, artificial,
@@ -39,6 +39,8 @@ const wordToSpan = (word, config, active, toggleActive) => {
 
   if (active && active.$.id === id) {
     classes.push(styles.active);
+  } else if (highlight.has(id)) {
+    classes.push(styles.highlight);
   }
 
   if (artificial === 'elliptic') {
@@ -74,12 +76,12 @@ const wordToSpan = (word, config, active, toggleActive) => {
 };
 
 const Text = ({
-  sentence, active, toggleActive, config,
+  sentence, active, toggleActive, highlight, config,
 }) => {
   const wordsCopy = [...sentence.word];
   const spans = wordsCopy
     .sort(compareWords)
-    .map((word) => wordToSpan(word, config, active, toggleActive));
+    .map((word) => wordToSpan(word, config, active, highlight, toggleActive));
 
   return (
     <div className={styles.text}>
@@ -94,12 +96,14 @@ Text.propTypes = {
   sentence: sentenceType.isRequired,
   active: wordType,
   toggleActive: func,
+  highlight: instanceOf(Set),
   config: instanceOf(Configuration).isRequired,
 };
 
 Text.defaultProps = {
   active: null,
   toggleActive: () => {},
+  highlight: new Set(),
 };
 
 export default Text;

--- a/src/lib/components/Text/Text.module.scss
+++ b/src/lib/components/Text/Text.module.scss
@@ -1,5 +1,5 @@
 .text {
-  background-color: rgb(242, 242, 242);
+  background-color: #f2f2f2;
   text-align: left;
 
   padding-top: 0.2rem;
@@ -17,12 +17,16 @@
   font-weight: 450;
 
   &:hover {
-    background-color: #5BC8DC;
+    background-color: #5bc8dc;
   }
 }
 
 .active {
-  background-color: rgb(246, 217, 24);
+  background-color: #f6d918;
+}
+
+.highlight {
+  background-color: #98eb09;
 }
 
 .elliptic {

--- a/src/lib/components/Text/Text.test.js
+++ b/src/lib/components/Text/Text.test.js
@@ -7,7 +7,6 @@ it('renders a sentence', () => {
   const component = (
     <Text
       sentence={{ word: [{ $: { id: '1', form: 'Ἡροδότου', postag: 'n-s---mg-' } }] }}
-      active={null}
       toggleActive={() => {}}
       config={global.defaultConfig}
     />
@@ -38,7 +37,6 @@ it('orders the words of a sentence correctly', () => {
   const component = (
     <Text
       sentence={sentence}
-      active={null}
       toggleActive={() => {}}
       config={global.defaultConfig}
     />
@@ -62,8 +60,31 @@ it('styles `artificial="elliptic"` words differently', () => {
   const component = (
     <Text
       sentence={sentence}
-      active={null}
       toggleActive={() => {}}
+      config={global.defaultConfig}
+    />
+  );
+  const tree = renderer.create(component).toJSON();
+
+  expect(tree).toMatchSnapshot();
+});
+
+it('displays highlighted and active words differently', () => {
+  const sentence = {
+    word: [
+      { $: { id: '1', form: 'Ἡροδότου', postag: 'n-s---mg-' } },
+      { $: { id: '2', form: 'Ἁλικαρνησσέος', postag: 'n-s---mg-' } },
+      { $: { id: '3', form: 'ἱστορίης', postag: 'n-s---fg-' } },
+      { $: { id: '4', form: 'ἀπόδεξις', postag: 'n-s---fn-' } },
+    ],
+  };
+
+  const component = (
+    <Text
+      sentence={sentence}
+      active={{ $: { id: '1' } }}
+      toggleActive={() => {}}
+      highlight={new Set(['1', '3'])}
       config={global.defaultConfig}
     />
   );

--- a/src/lib/components/Text/__snapshots__/Text.test.js.snap
+++ b/src/lib/components/Text/__snapshots__/Text.test.js.snap
@@ -1,5 +1,74 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`displays highlighted and active words differently 1`] = `
+<div
+  className="text"
+>
+  <p>
+    <span
+      className="word active"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+      style={
+        Object {
+          "color": "rgb(43, 114, 124)",
+        }
+      }
+      tabIndex="0"
+    >
+      Ἡροδότου
+    </span>
+     
+    <span
+      className="word"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+      style={
+        Object {
+          "color": "rgb(43, 114, 124)",
+        }
+      }
+      tabIndex="0"
+    >
+      Ἁλικαρνησσέος
+    </span>
+     
+    <span
+      className="word highlight"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+      style={
+        Object {
+          "color": "rgb(43, 114, 124)",
+        }
+      }
+      tabIndex="0"
+    >
+      ἱστορίης
+    </span>
+     
+    <span
+      className="word"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+      style={
+        Object {
+          "color": "rgb(43, 114, 124)",
+        }
+      }
+      tabIndex="0"
+    >
+      ἀπόδεξις
+    </span>
+     
+  </p>
+</div>
+`;
+
 exports[`orders the words of a sentence correctly 1`] = `
 <div
   className="text"

--- a/src/lib/components/Treebank/Graph/Graph.js
+++ b/src/lib/components/Treebank/Graph/Graph.js
@@ -7,8 +7,16 @@ import Graph from '../../Graph';
 const GraphWithContext = () => (
   <SentenceContext.Consumer>
     {({
-      sentence, active, toggleActive, config,
-    }) => <Graph sentence={sentence} active={active} toggleActive={toggleActive} config={config} />}
+      sentence, active, toggleActive, highlight, config,
+    }) => (
+      <Graph
+        sentence={sentence}
+        active={active}
+        toggleActive={toggleActive}
+        highlight={highlight}
+        config={config}
+      />
+    )}
   </SentenceContext.Consumer>
 );
 

--- a/src/lib/components/Treebank/Sentence/Sentence.js
+++ b/src/lib/components/Treebank/Sentence/Sentence.js
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from 'react';
-import { node, string, func } from 'prop-types';
+import {
+  node, string, func, arrayOf, instanceOf, oneOfType,
+} from 'prop-types';
 
 import styles from './Sentence.module.scss';
 
@@ -15,8 +17,16 @@ const findWord = (wordId, sentence) => (
 );
 
 const WrappedSentence = ({
-  // eslint-disable-next-line react/prop-types
-  id, callback, active: externalActiveId, setActive: externalSetActiveId, json, config, children,
+  /* eslint-disable react/prop-types */
+  id,
+  callback,
+  active: externalActiveId,
+  setActive: externalSetActiveId,
+  highlight: highlightIterable,
+  json,
+  config,
+  children,
+  /* eslint-enable react/prop-types */
 }) => {
   let activeId;
   let setActiveId;
@@ -27,6 +37,8 @@ const WrappedSentence = ({
   } else {
     [activeId, setActiveId] = useState(null);
   }
+
+  const highlight = new Set(highlightIterable);
 
   const sentence = sentenceFromJson(json, id);
 
@@ -58,6 +70,7 @@ const WrappedSentence = ({
       config,
       active,
       toggleActive,
+      highlight,
     }}
     >
       <div className={styles.container}>
@@ -68,7 +81,7 @@ const WrappedSentence = ({
 };
 
 const Sentence = ({
-  id, callback, active, setActive, children,
+  id, callback, active, setActive, highlight, children,
 }) => (
   <TreebankContext.Consumer>
     {({ json, config }) => (
@@ -77,6 +90,7 @@ const Sentence = ({
         callback={callback}
         active={active}
         setActive={setActive}
+        highlight={highlight}
         json={json}
         config={config}
       >
@@ -91,6 +105,7 @@ Sentence.propTypes = {
   callback: func,
   active: string,
   setActive: func,
+  highlight: oneOfType([arrayOf(string), instanceOf(Set)]),
   children: node,
 };
 
@@ -98,6 +113,7 @@ Sentence.defaultProps = {
   callback: null,
   active: null,
   setActive: null,
+  highlight: [],
   children: null,
 };
 

--- a/src/lib/components/Treebank/Text/Text.js
+++ b/src/lib/components/Treebank/Text/Text.js
@@ -7,9 +7,15 @@ import Text from '../../Text';
 const TextWithContext = () => (
   <SentenceContext.Consumer>
     {({
-      sentence, active, toggleActive, config,
+      sentence, active, toggleActive, highlight, config,
     }) => (
-      <Text sentence={sentence} active={active} toggleActive={toggleActive} config={config} />
+      <Text
+        sentence={sentence}
+        active={active}
+        highlight={highlight}
+        toggleActive={toggleActive}
+        config={config}
+      />
     )}
   </SentenceContext.Consumer>
 );

--- a/src/lib/components/Treebank/Xml/Xml.js
+++ b/src/lib/components/Treebank/Xml/Xml.js
@@ -6,8 +6,15 @@ import Xml from '../../Xml';
 
 const XmlWithContext = () => (
   <SentenceContext.Consumer>
-    {({ sentence, active, toggleActive }) => (
-      <Xml sentence={sentence} active={active} toggleActive={toggleActive} />
+    {({
+      sentence, active, toggleActive, highlight,
+    }) => (
+      <Xml
+        sentence={sentence}
+        active={active}
+        toggleActive={toggleActive}
+        highlight={highlight}
+      />
     )}
   </SentenceContext.Consumer>
 );

--- a/src/lib/components/Xml/Xml.js
+++ b/src/lib/components/Xml/Xml.js
@@ -1,5 +1,5 @@
 import React, { Fragment } from 'react';
-import { func } from 'prop-types';
+import { func, instanceOf } from 'prop-types';
 
 import { sentenceType, wordType } from '../../types';
 
@@ -47,10 +47,9 @@ const closingTag = (name, key) => (
   </Fragment>
 );
 
-const renderWord = (word, active, toggleActive) => {
+const renderWord = (word, active, toggleActive, highlight) => {
   const { $: { id } } = word;
-  const isActive = active && active.$.id === id;
-  const className = isActive ? [styles.word, styles.active].join(' ') : styles.word;
+  const classes = [styles.word];
   const onClick = () => {
     toggleActive(id);
   };
@@ -62,12 +61,18 @@ const renderWord = (word, active, toggleActive) => {
     }
   };
 
+  if (active && active.$.id === id) {
+    classes.push(styles.active);
+  } else if (highlight.has(id)) {
+    classes.push(styles.highlight);
+  }
+
   return (
     <div
       key={id}
       role="button"
       tabIndex="0"
-      className={className}
+      className={classes.join(' ')}
       onClick={onClick}
       onKeyDown={onKeyDown}
     >
@@ -76,11 +81,13 @@ const renderWord = (word, active, toggleActive) => {
   );
 };
 
-const Xml = ({ sentence, active, toggleActive }) => (
+const Xml = ({
+  sentence, active, toggleActive, highlight,
+}) => (
   <div className={styles.xml}>
     {openingTag('sentence', sentence.$, 'sentence')}
     {sentence.word.map((word) => (
-      renderWord(word, active, toggleActive)
+      renderWord(word, active, toggleActive, highlight)
     ))}
     {closingTag('sentence', 'sentence-close')}
   </div>
@@ -90,11 +97,13 @@ Xml.propTypes = {
   sentence: sentenceType.isRequired,
   active: wordType,
   toggleActive: func,
+  highlight: instanceOf(Set),
 };
 
 Xml.defaultProps = {
   active: null,
   toggleActive: () => {},
+  highlight: new Set(),
 };
 
 export default Xml;

--- a/src/lib/components/Xml/Xml.module.scss
+++ b/src/lib/components/Xml/Xml.module.scss
@@ -24,6 +24,10 @@
   background-color: rgb(246, 217, 24);
 }
 
+.highlight {
+  background-color: #98eb09;
+}
+
 .bracket {
   color: rgb(0, 0, 255);
 }

--- a/src/lib/components/Xml/Xml.test.js
+++ b/src/lib/components/Xml/Xml.test.js
@@ -29,3 +29,28 @@ it('renders a sentence as XML', () => {
 
   expect(tree).toMatchSnapshot();
 });
+
+it('displays highlighted and active words differently', () => {
+  const sentence = {
+    $: {
+      id: '1', document_id: 'test', subdoc: '2', span: '',
+    },
+    word: [
+      { $: { id: '1', form: 'Ἡροδότου', postag: 'n-s---mg-' } },
+      { $: { id: '2', form: 'Ἁλικαρνησσέος', postag: 'n-s---mg-' } },
+      { $: { id: '3', form: 'ἱστορίης', postag: 'n-s---fg-' } },
+      { $: { id: '4', form: 'ἀπόδεξις', postag: 'n-s---fn-' } },
+    ],
+  };
+
+  const component = (
+    <Xml
+      sentence={sentence}
+      active={{ $: { id: '1' } }}
+      highlight={new Set(['1', '3'])}
+    />
+  );
+  const tree = renderer.create(component).toJSON();
+
+  expect(tree).toMatchSnapshot();
+});

--- a/src/lib/components/Xml/__snapshots__/Xml.test.js.snap
+++ b/src/lib/components/Xml/__snapshots__/Xml.test.js.snap
@@ -1,5 +1,374 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`displays highlighted and active words differently 1`] = `
+<div
+  className="xml"
+>
+  <span
+    className="bracket"
+  >
+    
+    &lt;
+  </span>
+  <span
+    className="element"
+  >
+    sentence
+  </span>
+   
+  <span
+    className="attribute"
+  >
+    id
+    =
+  </span>
+  <span
+    className="attributeText"
+  >
+    "
+    1
+    "
+  </span>
+   
+  <span
+    className="attribute"
+  >
+    document_id
+    =
+  </span>
+  <span
+    className="attributeText"
+  >
+    "
+    test
+    "
+  </span>
+   
+  <span
+    className="attribute"
+  >
+    subdoc
+    =
+  </span>
+  <span
+    className="attributeText"
+  >
+    "
+    2
+    "
+  </span>
+   
+  <span
+    className="attribute"
+  >
+    span
+    =
+  </span>
+  <span
+    className="attributeText"
+  >
+    "
+    
+    "
+  </span>
+  
+  <span
+    className="bracket"
+  >
+    &gt;
+  </span>
+  <br />
+  <div
+    className="word active"
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    role="button"
+    tabIndex="0"
+  >
+    <span
+      className="bracket"
+    >
+          
+      &lt;
+    </span>
+    <span
+      className="element"
+    >
+      word
+    </span>
+     
+    <span
+      className="attribute"
+    >
+      id
+      =
+    </span>
+    <span
+      className="attributeText"
+    >
+      "
+      1
+      "
+    </span>
+     
+    <span
+      className="attribute"
+    >
+      form
+      =
+    </span>
+    <span
+      className="attributeText"
+    >
+      "
+      Ἡροδότου
+      "
+    </span>
+     
+    <span
+      className="attribute"
+    >
+      postag
+      =
+    </span>
+    <span
+      className="attributeText"
+    >
+      "
+      n-s---mg-
+      "
+    </span>
+     /
+    <span
+      className="bracket"
+    >
+      &gt;
+    </span>
+    <br />
+  </div>
+  <div
+    className="word"
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    role="button"
+    tabIndex="0"
+  >
+    <span
+      className="bracket"
+    >
+          
+      &lt;
+    </span>
+    <span
+      className="element"
+    >
+      word
+    </span>
+     
+    <span
+      className="attribute"
+    >
+      id
+      =
+    </span>
+    <span
+      className="attributeText"
+    >
+      "
+      2
+      "
+    </span>
+     
+    <span
+      className="attribute"
+    >
+      form
+      =
+    </span>
+    <span
+      className="attributeText"
+    >
+      "
+      Ἁλικαρνησσέος
+      "
+    </span>
+     
+    <span
+      className="attribute"
+    >
+      postag
+      =
+    </span>
+    <span
+      className="attributeText"
+    >
+      "
+      n-s---mg-
+      "
+    </span>
+     /
+    <span
+      className="bracket"
+    >
+      &gt;
+    </span>
+    <br />
+  </div>
+  <div
+    className="word highlight"
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    role="button"
+    tabIndex="0"
+  >
+    <span
+      className="bracket"
+    >
+          
+      &lt;
+    </span>
+    <span
+      className="element"
+    >
+      word
+    </span>
+     
+    <span
+      className="attribute"
+    >
+      id
+      =
+    </span>
+    <span
+      className="attributeText"
+    >
+      "
+      3
+      "
+    </span>
+     
+    <span
+      className="attribute"
+    >
+      form
+      =
+    </span>
+    <span
+      className="attributeText"
+    >
+      "
+      ἱστορίης
+      "
+    </span>
+     
+    <span
+      className="attribute"
+    >
+      postag
+      =
+    </span>
+    <span
+      className="attributeText"
+    >
+      "
+      n-s---fg-
+      "
+    </span>
+     /
+    <span
+      className="bracket"
+    >
+      &gt;
+    </span>
+    <br />
+  </div>
+  <div
+    className="word"
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    role="button"
+    tabIndex="0"
+  >
+    <span
+      className="bracket"
+    >
+          
+      &lt;
+    </span>
+    <span
+      className="element"
+    >
+      word
+    </span>
+     
+    <span
+      className="attribute"
+    >
+      id
+      =
+    </span>
+    <span
+      className="attributeText"
+    >
+      "
+      4
+      "
+    </span>
+     
+    <span
+      className="attribute"
+    >
+      form
+      =
+    </span>
+    <span
+      className="attributeText"
+    >
+      "
+      ἀπόδεξις
+      "
+    </span>
+     
+    <span
+      className="attribute"
+    >
+      postag
+      =
+    </span>
+    <span
+      className="attributeText"
+    >
+      "
+      n-s---fn-
+      "
+    </span>
+     /
+    <span
+      className="bracket"
+    >
+      &gt;
+    </span>
+    <br />
+  </div>
+  <span
+    className="bracket"
+  >
+    &lt;
+  </span>
+  <span
+    className="element"
+  >
+    /
+    sentence
+  </span>
+  <span
+    className="bracket"
+  >
+    &gt;
+  </span>
+</div>
+`;
+
 exports[`renders a sentence as XML 1`] = `
 <div
   className="xml"

--- a/src/lib/utils/parsing.js
+++ b/src/lib/utils/parsing.js
@@ -9,7 +9,7 @@ const xmlToJson = (xml) => {
   return json;
 };
 
-const createNode = (word, active, config, styles) => {
+const createNode = (word, active, highlight, config, styles) => {
   const {
     $: {
       id, form, postag, artificial,
@@ -17,10 +17,15 @@ const createNode = (word, active, config, styles) => {
   } = word;
   const color = config.getColor(postag);
   const isActive = active && active.$.id === id;
+  const isHighlighted = !isActive && highlight.has(id);
   const classes = [styles.node];
 
   if (isActive) {
     classes.push(styles.active);
+  }
+
+  if (isHighlighted) {
+    classes.push(styles.highlight);
   }
 
   if (artificial === 'elliptic') {
@@ -37,6 +42,7 @@ const createNode = (word, active, config, styles) => {
       labelType: 'html',
       class: classes.join(' '),
       isActive,
+      isHighlighted,
     },
   };
 };
@@ -62,11 +68,11 @@ const createLink = (word) => {
   return null;
 };
 
-const sentenceToGraph = (sentence, active, config, styles) => {
+const sentenceToGraph = (sentence, active, highlight, config, styles) => {
   const graph = { nodes: [{ id: '0', label: '[ROOT]', config: { labelType: 'html', class: styles.node } }], links: [] };
 
   sentence.word.forEach((word) => {
-    const node = createNode(word, active, config, styles);
+    const node = createNode(word, active, highlight, config, styles);
     const link = createLink(word);
 
     graph.nodes.push(node);


### PR DESCRIPTION
Fixes https://github.com/perseids-tools/treebank-react/issues/25

Add the `highlight` prop to `<Sentence>`. This prop is an array (that's converted to a Set internally) and is passed to all children. It represents words that should be emphasized in some way.

Update the `<Text>`, `<Xml>`, and `<Graph>` components to change the background color of all highlighted words.

In the screenshot below, the first 11 words (including punctuation) are highlighted,


---

<img width="1086" alt="screenshot" src="https://user-images.githubusercontent.com/3039310/111680902-12fb5600-87f9-11eb-9b51-330e3991081f.png">


---

What this means for the user of the library is that they can highlight words by adding `highlight={["array", "of", "ids"]}` to the `<Sentence>` component. To test it locally, [set up](https://github.com/perseids-tools/treebank-react#development) the local development environment and change line 78 of [src/demo/App/App.js](https://github.com/perseids-tools/treebank-react/blob/master/src/demo/App/App.js#L78) to:

```
<Sentence id="1" highlight={["1", "10", "11"]}>
```