### PR TITLE
Remove sentence div

### DIFF
--- a/src/lib/components/Collapse/Collapse.js
+++ b/src/lib/components/Collapse/Collapse.js
@@ -12,7 +12,7 @@ const Collapse = ({ title, children, collapsed: beginCollapsed }) => {
   }, [beginCollapsed]);
 
   return (
-    <>
+    <div>
       <button type="button" className={styles.button} onClick={toggleCollapse}>
         <div>
           {title}
@@ -22,7 +22,7 @@ const Collapse = ({ title, children, collapsed: beginCollapsed }) => {
         </div>
       </button>
       {collapsed ? null : children}
-    </>
+    </div>
   );
 };
 

--- a/src/lib/components/Collapse/Collapse.module.scss
+++ b/src/lib/components/Collapse/Collapse.module.scss
@@ -2,6 +2,7 @@
   background-color: #8f8f8f;
   color: #ffffff;
   font-size: 1rem;
+  width: 100%;
 
   display: flex;
   justify-content: space-between;

--- a/src/lib/components/Collapse/__snapshots__/Collapse.test.js.snap
+++ b/src/lib/components/Collapse/__snapshots__/Collapse.test.js.snap
@@ -1,24 +1,26 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders collapsed 1`] = `
-<button
-  className="button"
-  onClick={[Function]}
-  type="button"
->
-  <div>
-    Title
-  </div>
-  <div
-    className="right"
+<div>
+  <button
+    className="button"
+    onClick={[Function]}
+    type="button"
   >
-    +
-  </div>
-</button>
+    <div>
+      Title
+    </div>
+    <div
+      className="right"
+    >
+      +
+    </div>
+  </button>
+</div>
 `;
 
 exports[`renders uncollapsed 1`] = `
-Array [
+<div>
   <button
     className="button"
     onClick={[Function]}
@@ -32,9 +34,9 @@ Array [
     >
       -
     </div>
-  </button>,
+  </button>
   <div>
     Hello world
-  </div>,
-]
+  </div>
+</div>
 `;

--- a/src/lib/components/Treebank/Sentence/Sentence.js
+++ b/src/lib/components/Treebank/Sentence/Sentence.js
@@ -3,8 +3,6 @@ import {
   node, string, func, arrayOf, instanceOf, oneOfType,
 } from 'prop-types';
 
-import styles from './Sentence.module.scss';
-
 import TreebankContext from '../treebank-context';
 import SentenceContext from '../sentence-context';
 
@@ -73,9 +71,7 @@ const WrappedSentence = ({
       highlight,
     }}
     >
-      <div className={styles.container}>
-        {children}
-      </div>
+      {children}
     </SentenceContext.Provider>
   );
 };

--- a/src/lib/components/Treebank/Sentence/Sentence.module.scss
+++ b/src/lib/components/Treebank/Sentence/Sentence.module.scss
@@ -1,3 +1,0 @@
-.container {
-  display: grid;
-}


### PR DESCRIPTION
Remove extra `<div>` created by `<Sentence>` component. This change means that the JSX

```jsx
<Sentence>
  <span>hello</span>
</Sentence>
```

will produce the HTML

```html
<span>hello</span>
```

and not

```html
<div>
  <span>hello</span>
</div>
```