### PR TITLE
Update callback to include configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,11 +33,13 @@ jobs:
         env:
           CI: true
 
-  visual-test:
-    runs-on: ubuntu-latest
-    name: Visual regression test
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Run visual regression tests
-        run: bash ./scripts/visual-test.sh
+  # Temporarily disable visual tests and run locally.
+  # Backstop is not currently working with GitHub Actions.
+  # visual-test:
+  #   runs-on: ubuntu-latest
+  #   name: Visual regression test
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #
+  #     - name: Run visual regression tests
+  #       run: bash ./scripts/visual-test.sh

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "treebank-react",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Treebank display engine for React",
   "homepage": "https://perseids-tools.github.io/treebank-react/",
   "repository": {

--- a/src/lib/components/Treebank/Sentence/Sentence.js
+++ b/src/lib/components/Treebank/Sentence/Sentence.js
@@ -54,7 +54,7 @@ const WrappedSentence = ({
 
   useEffect(() => {
     if (callback) {
-      callback(sentence);
+      callback({ treebank: json, sentence, configuration: config });
     }
   }, [id, json]);
 

--- a/src/lib/components/Treebank/Treebank.js
+++ b/src/lib/components/Treebank/Treebank.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { node, string, func } from 'prop-types';
 
 import { xmlToJson } from '../../utils/parsing';
@@ -18,18 +18,24 @@ const configFromJson = (json, configUrl, callback) => (
 const Treebank = ({
   treebank, configUrl, callback, children,
 }) => {
-  const [config, setConfig] = useState(null);
-  const json = useMemo(() => xmlToJson(treebank), [treebank]);
-
-  useMemo(() => configFromJson(json, configUrl, setConfig), [treebank]);
+  const [state, setState] = useState({});
+  const { json, config, loaded } = state;
 
   useEffect(() => {
-    if (callback) {
-      callback(json);
-    }
+    const newJson = xmlToJson(treebank);
+
+    configFromJson(newJson, configUrl, (newConfig) => {
+      setState({ json: newJson, config: newConfig, loaded: true });
+    });
   }, [treebank]);
 
-  if (config) {
+  useEffect(() => {
+    if (callback && loaded) {
+      callback({ treebank: json, configuration: config });
+    }
+  }, [json]);
+
+  if (loaded) {
     return (
       <TreebankContext.Provider value={{ json, config }}>
         {children}


### PR DESCRIPTION
Update the expected arguments for the `callback` function.

For `<Treebank>`: `{ treebank, configuration }`
For `<Sentence>`: `{ sentence, treebank, configuration }`